### PR TITLE
optimize method useSpecialProperty

### DIFF
--- a/src/abitbol.js
+++ b/src/abitbol.js
@@ -15,9 +15,9 @@ function inherit(SuperClass) {
 // Checks if the given function uses abitbol special properties ($super, $name,...)
 function usesSpecialProperty(fn) {
     var fnString = fn.toString();
-    return Boolean(fnString.indexOf("$super") > -1
-                    || fnString.indexOf("$name") > -1
-                    || fnString.indexOf("$computedPropertyName") > -1)
+    return fnString.indexOf("$super") > -1
+        || fnString.indexOf("$name") > -1
+        || fnString.indexOf("$computedPropertyName") > -1
 }
 
 var Class = function () {};

--- a/src/abitbol.js
+++ b/src/abitbol.js
@@ -14,7 +14,10 @@ function inherit(SuperClass) {
 
 // Checks if the given function uses abitbol special properties ($super, $name,...)
 function usesSpecialProperty(fn) {
-    return Boolean(fn.toString().match(/.*(\$super|\$name|\$computedPropertyName).*/));
+    var fnString = fn.toString();
+    return Boolean(fnString.indexOf("$super") > -1
+                    || fnString.indexOf("$name") > -1
+                    || fnString.indexOf("$computedPropertyName") > -1)
 }
 
 var Class = function () {};


### PR DESCRIPTION
Optimisation of method usesSpecialProperty

Using String.indexOf instead of Regex

* Before

![image](https://user-images.githubusercontent.com/2399164/110133790-032d4c00-7dcd-11eb-8b06-f03ce07dd823.png)

* After
* 
![image](https://user-images.githubusercontent.com/2399164/110133882-1a6c3980-7dcd-11eb-8a98-1056f19cc895.png)
